### PR TITLE
Balance spliterator: sort periods

### DIFF
--- a/src/main/java/be/valuya/accountingtroll/cache/AccountBalanceSpliterator.java
+++ b/src/main/java/be/valuya/accountingtroll/cache/AccountBalanceSpliterator.java
@@ -8,6 +8,7 @@ import be.valuya.accountingtroll.domain.ATBookPeriod;
 import be.valuya.accountingtroll.domain.ATPeriodType;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Spliterator;
@@ -29,6 +30,8 @@ public class AccountBalanceSpliterator implements Spliterator<ATAccountBalance> 
         this.allPeriods = allPeriods;
         this.accountBalancesCache = new AccountBalancesCache(allPeriods);
         this.curPeriodIndex = 0;
+
+        Collections.sort(allPeriods);
     }
 
     public void setIgnoreIntermediatePeriodOpeningEntry(boolean ignoreIntermediatePeriodOpeningEntry) {


### PR DESCRIPTION
spliterator was relying on sorted periods yet input list ordering was not checked.